### PR TITLE
Fix import and some rearranging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # mdn-storybook
 
 UI components for MDN Web Docs
+
+## Getting Started
+
+1. Run `npm install` to install dependencies
+2. Run `npm run storybook` to start Storybook
+3. Visit http://localhost:9009 in your browser

--- a/src/components/Logo/Logo.jsx
+++ b/src/components/Logo/Logo.jsx
@@ -2,10 +2,10 @@ import React from "react";
 
 import PropTypes from "prop-types";
 
-import { gettext } from "../utils/l10n.js";
+import { gettext } from "../../utils/l10n.js";
 
-import { ReactComponent as LogoSVG } from "../media/svg/logo.svg";
-import "../style/components/logo.scss";
+import { ReactComponent as LogoSVG } from "../../media/svg/logo.svg";
+import "../../style/components/logo.scss";
 
 export default function Logo({ locale }) {
   return (

--- a/src/components/Logo/Logo.stories.js
+++ b/src/components/Logo/Logo.stories.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
 
-import Logo from "./logo.jsx";
+import Logo from "./Logo.jsx";
 
 storiesOf("Logo", module)
   .add("default", () => <Logo locale="en-US" />)

--- a/src/components/MainNav/MainNav.jsx
+++ b/src/components/MainNav/MainNav.jsx
@@ -2,10 +2,10 @@
 import * as React from "react";
 import { memo, useMemo, useState } from "react";
 
-import { gettext } from "../utils/l10n.js";
-import type { DocumentData } from "../types/document-data.js";
+import { gettext } from "../../utils/l10n.js";
+import type { DocumentData } from "../../types/document-data.js";
 
-import "../style/components/_main-nav.scss";
+import "../../style/components/_main-nav.scss";
 
 type Props = {
   document?: ?DocumentData,

--- a/src/components/MainNav/MainNav.stories.js
+++ b/src/components/MainNav/MainNav.stories.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
 
-import MainNav from "./main-nav.jsx";
+import MainNav from "./MainNav.jsx";
 
 storiesOf("MainNav", module)
   .add("default", () => <MainNav locale="en-US" />)


### PR DESCRIPTION
- Fix case on `logo` import, which was causing a Storybook error 
- Update README with some instructions
- Move files into folders for better organization, as it might become hard to find them as the components grow